### PR TITLE
Remove warning message, since FW 16 is now in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ For reference firmware for different types of modules, check out these additiona
  * [QMK firmware](https://github.com/frameworkcomputer/qmk_firmware) for the keyboard and numpad modules
  * [inputmodule-rs](https://github.com/FrameworkComputer/inputmodule-rs) firmware and application for other input modules
 
-**Warning:** the documentation here is pretty early, so there may be minor adjustments in the mechanical or electrical designs
-before the Framework Laptop 16 launches.  We'll let you know when the design is locked for production.
- 
 ## License
 Input Modules © 2023 by Framework Computer Inc is licensed under CC BY 4.0. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/
 


### PR DESCRIPTION
FW16 is in production now, the warning is outdated
