### PR TITLE
Add a note about the BOARD_ID logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The Framework Laptop 16 has a protection scheme in place to prevent Input Module
 Module detection is done using the BOARD_ID pin. It is possible to override this setting on the system, but at the risk of shorting the system
 or modules.
 
+Note that although a "keyboard size" module has pads on the left and right
+hand side that it can interface with, the module detection expects the
+BOARD_ID pin to be connected on the left hand side.
+
 ## Touchpad Module
 
 This section describes the Touchpad Module connection on the **system** side, including the pin define and the pin map of the connector.


### PR DESCRIPTION
I've tested the firmware logic and found that it does not handle the
two possible pads for the keyboard symmetrically.  This patch updates
the spec, but another option would be to patch the EC firmware to
recognize keyboard-sized modules with their primary connection on
the right hand side.
